### PR TITLE
Prepare twig template

### DIFF
--- a/src/ContaoTwig/TwigTemplate.php
+++ b/src/ContaoTwig/TwigTemplate.php
@@ -154,7 +154,7 @@ class TwigTemplate
         ) {
             foreach ($GLOBALS['TL_HOOKS']['prepareTwigTemplate'] as $callback) {
                 $object = \System::importStatic($callback[0]);
-                $object->$callback[1]($this);
+                $object->$callback[1]($this, $context);
             }
         }
 


### PR DESCRIPTION
When i will override the template file.
In the moment i must use the hook parseTwigTemplate.
I will use the hook prepareTwigTemplate, this is better otherwise
i must render the template in twice moments.

By using prepareTwigTemplate hook i have no really informations 